### PR TITLE
feat(www): add mock coin detail page

### DIFF
--- a/www/src/App.tsx
+++ b/www/src/App.tsx
@@ -7,6 +7,7 @@ import { RpcRequestDetail } from '@/components/RpcRequestDetail';
 import { SeekTransaction } from '@/components/SeekTransaction';
 import { MarketList } from '@/components/MarketList';
 import { MarketDetail } from '@/components/MarketDetail';
+import { CoinDetail } from '@/components/CoinDetail';
 import { ComparisonProvider } from './context/ComparisonContext';
 
 function App() {
@@ -18,6 +19,7 @@ function App() {
             <Route path="/" element={<TransactionList />} />
             <Route path="/markets" element={<MarketList />} />
             <Route path="/market/:address" element={<MarketDetail />} />
+            <Route path="/coin/:ticker" element={<CoinDetail />} />
             <Route path="/seek" element={<SeekTransaction />} />
             <Route path="/transaction/:id" element={<TransactionDetail />} />
             <Route path="/rpc-requests" element={<RpcRequestList />} />

--- a/www/src/components/CoinDetail.tsx
+++ b/www/src/components/CoinDetail.tsx
@@ -1,0 +1,139 @@
+import { useState, useEffect } from 'react';
+import { useParams } from 'react-router-dom';
+import { CoinDetails } from '@/types';
+import { fetchCoin } from '@/lib/api';
+
+function formatDate(dateStr: string) {
+  return new Date(dateStr).toLocaleDateString();
+}
+
+function getAge(dateStr: string) {
+  const diffMs = Date.now() - new Date(dateStr).getTime();
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+  return `${diffDays} days`;
+}
+
+export function CoinDetail() {
+  const { ticker } = useParams<{ ticker: string }>();
+  const [coin, setCoin] = useState<CoinDetails | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function loadCoin() {
+      if (!ticker) return;
+      try {
+        const data = await fetchCoin(ticker);
+        setCoin(data);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'An unknown error occurred');
+      } finally {
+        setLoading(false);
+      }
+    }
+    loadCoin();
+  }, [ticker]);
+
+  useEffect(() => {
+    if (!coin) return;
+    async function renderChart() {
+      // @ts-ignore - Using CDN module for demo purposes
+      const Chart = (await import('https://cdn.jsdelivr.net/npm/chart.js@4.3.0/dist/chart.umd.js')).default;
+      const ctx = document.getElementById('coin-chart') as HTMLCanvasElement;
+      if (ctx) {
+        new Chart(ctx, {
+          type: 'line',
+          data: {
+            labels: coin.price_history.map((p) => p.date),
+            datasets: [
+              {
+                label: 'USD Price',
+                data: coin.price_history.map((p) => p.price),
+              },
+            ],
+          },
+        });
+      }
+    }
+    renderChart();
+  }, [coin]);
+
+  if (loading) {
+    return <div>Loading coin...</div>;
+  }
+
+  if (error) {
+    return <div>Error: {error}</div>;
+  }
+
+  if (!coin) {
+    return <div>Coin not found.</div>;
+  }
+
+  const unifiedPrice =
+    coin.markets.reduce((acc, m) => acc + m.price, 0) / coin.markets.length;
+
+  return (
+    <div className="container mx-auto p-4">
+      <div className="flex items-center mb-4">
+        <img src={coin.image} alt={`${coin.name} logo`} className="w-16 h-16 mr-4" />
+        <div>
+          <h1 className="text-2xl font-bold">
+            {coin.name} ({coin.ticker})
+          </h1>
+          <p className="text-sm text-gray-600">{coin.chain}</p>
+          <p className="text-sm">Address: {coin.address}</p>
+          <p className="text-sm">
+            Created: {formatDate(coin.created_at)} ({getAge(coin.created_at)} old)
+          </p>
+          <p className="text-sm">Unified USD Price: ${unifiedPrice.toFixed(2)}</p>
+          <div className="flex space-x-2 mt-2">
+            <a href={coin.website} className="text-blue-500" target="_blank" rel="noopener noreferrer">
+              Website
+            </a>
+            {Object.entries(coin.socials).map(([name, url]) => (
+              <a
+                key={name}
+                href={url}
+                className="text-blue-500 capitalize"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {name}
+              </a>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div className="mb-8">
+        <canvas id="coin-chart" height="100"></canvas>
+      </div>
+
+      <div className="mb-8">
+        <h2 className="text-xl font-bold mb-2">Markets</h2>
+        <ul>
+          {coin.markets.map((m) => (
+            <li key={m.name} className="flex justify-between">
+              <span>{m.name}</span>
+              <span>${m.price}</span>
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      <div>
+        <h2 className="text-xl font-bold mb-2">Recent Transactions</h2>
+        <ul>
+          {coin.transactions.map((t) => (
+            <li key={t.id} className="flex justify-between text-sm border-b py-1">
+              <span>{t.type}</span>
+              <span>{t.amount}</span>
+              <span>{new Date(t.timestamp).toLocaleString()}</span>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/www/src/components/SeekTransaction.tsx
+++ b/www/src/components/SeekTransaction.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';

--- a/www/src/lib/api.ts
+++ b/www/src/lib/api.ts
@@ -1,4 +1,4 @@
-import { Transaction, RpcRequest, Market, MarketDetails } from '@/types';
+import { Transaction, RpcRequest, Market, MarketDetails, CoinDetails } from '@/types';
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000';
 
@@ -50,6 +50,42 @@ export async function fetchMarkets(): Promise<Market[]> {
     throw new Error('Failed to fetch markets');
   }
   return response.json();
+}
+
+// TODO: Replace mock implementation with real API call once backend is ready
+export async function fetchCoin(ticker: string): Promise<CoinDetails> {
+  // Simulate network delay
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve({
+        ticker,
+        name: 'Mock Coin',
+        chain: 'Ethereum',
+        address: '0x1234567890abcdef',
+        created_at: '2023-01-01T00:00:00Z',
+        image: 'https://via.placeholder.com/64',
+        website: 'https://example.com',
+        socials: {
+          twitter: 'https://twitter.com/example',
+          github: 'https://github.com/example',
+        },
+        markets: [
+          { name: 'MarketA', price: 1.23 },
+          { name: 'MarketB', price: 1.25 },
+        ],
+        price_history: [
+          { date: '2024-01-01', price: 1.0 },
+          { date: '2024-02-01', price: 1.1 },
+          { date: '2024-03-01', price: 1.2 },
+          { date: '2024-04-01', price: 1.3 },
+        ],
+        transactions: [
+          { id: 'tx1', type: 'swap', amount: 100, timestamp: '2024-05-01T12:00:00Z' },
+          { id: 'tx2', type: 'transfer', amount: 50, timestamp: '2024-05-02T15:30:00Z' },
+        ],
+      });
+    }, 300);
+  });
 }
 
 export async function fetchRpcRequest(id: string): Promise<RpcRequest> {

--- a/www/src/types.ts
+++ b/www/src/types.ts
@@ -32,3 +32,34 @@ export interface Market {
 export interface MarketDetails extends Market {
   metadata: any;
 }
+
+export interface CoinMarket {
+  name: string;
+  price: number; // Market-specific price in USD
+}
+
+export interface CoinTransaction {
+  id: string;
+  type: string; // e.g. swap, transfer
+  amount: number;
+  timestamp: string;
+}
+
+export interface PricePoint {
+  date: string;
+  price: number;
+}
+
+export interface CoinDetails {
+  ticker: string;
+  name: string;
+  chain: string;
+  address: string;
+  created_at: string;
+  image: string;
+  website: string;
+  socials: Record<string, string>;
+  markets: CoinMarket[];
+  price_history: PricePoint[];
+  transactions: CoinTransaction[];
+}


### PR DESCRIPTION
## Summary
- add coin detail route with mock data and chart placeholder
- wire up mock API call and supporting types for future backend work
- fix SeekTransaction missing React import for linting

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `deno test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68971eacc9808321afa8f6177c875cd4